### PR TITLE
Fixed the invalid Go module path of the plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module steampipe-plugin-newrelic
+module github.com/turbot/steampipe-plugin-newrelic
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"steampipe-plugin-newrelic/newrelic"
+	"github.com/turbot/steampipe-plugin-newrelic/newrelic"
 )
 
 func main() {


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
